### PR TITLE
Fix URL encoding in request URLs

### DIFF
--- a/Classes/BSForwardGeocoder.m
+++ b/Classes/BSForwardGeocoder.m
@@ -9,6 +9,7 @@
 //
 
 #import "BSForwardGeocoder.h"
+#import "NSString+URLEncode.h"
 
 
 @implementation BSForwardGeocoder
@@ -53,11 +54,11 @@
 	if (version == 2) {
 		// Create the url to Googles geocoding API, we want the response to be in XML
 		NSString* mapsUrl = [[NSString alloc] initWithFormat:@"%@://maps.google.com/maps/geo?q=%@&gl=se&output=xml&oe=utf8&sensor=false", 
-							 useHTTP ? @"http" : @"https", searchQuery];
+							 useHTTP ? @"http" : @"https", [searchQuery URLEncodedString]];
 		
 		// Create the url object for our request. It's important to escape the 
 		// search string to support spaces and international characters
-		NSURL *url = [[NSURL alloc] initWithString:[mapsUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+		NSURL *url = [[NSURL alloc] initWithString:mapsUrl];
 		
 		// Run the KML parser
 		BSGoogleV2KmlParser *parser = [[BSGoogleV2KmlParser alloc] init];
@@ -78,11 +79,11 @@
 	else if (version == 3) {
 		// Create the url to Googles geocoding API, we want the response to be in XML
 		NSString* mapsUrl = [[NSString alloc] initWithFormat:@"%@://maps.google.com/maps/api/geocode/xml?address=%@&sensor=false", 
-							 useHTTP ? @"http" : @"https", searchQuery];
+							 useHTTP ? @"http" : @"https", [searchQuery URLEncodedString]];
 		
 		// Create the url object for our request. It's important to escape the 
 		// search string to support spaces and international characters
-		NSURL *url = [[NSURL alloc] initWithString:[mapsUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+		NSURL *url = [[NSURL alloc] initWithString:mapsUrl];
 		
 		// Run the KML parser
 		BSGoogleV3KmlParser *parser = [[BSGoogleV3KmlParser alloc] init];

--- a/Classes/NSString+URLEncode.h
+++ b/Classes/NSString+URLEncode.h
@@ -1,0 +1,14 @@
+//
+//  NO Copyright 2010 MightyLittle Industries. NO rights reserved.
+//
+//  Use this code any way you like. If you do like it, please
+//  link to my blog and/or write a friendly comment. Thank you!
+//
+//  Read my blog @ http://blog.sallarp.com
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (URLEncode)
+- (NSString *)URLEncodedString;
+@end

--- a/Classes/NSString+URLEncode.m
+++ b/Classes/NSString+URLEncode.m
@@ -1,0 +1,28 @@
+//
+//  NO Copyright 2010 MightyLittle Industries. NO rights reserved.
+//
+//  Use this code any way you like. If you do like it, please
+//  link to my blog and/or write a friendly comment. Thank you!
+//
+//  Read my blog @ http://blog.sallarp.com
+//
+
+#import "NSString+URLEncode.h"
+
+@implementation NSString (URLEncode)
+
+// Use Core Foundation method to URL-encode strings, since -stringByAddingPercentEscapesUsingEncoding:
+// doesn't do a complete job. For details, see:
+//   http://simonwoodside.com/weblog/2009/4/22/how_to_really_url_encode/
+//   http://stackoverflow.com/questions/730101/how-do-i-encode-in-a-url-in-an-html-attribute-value/730427#730427
+- (NSString *)URLEncodedString
+{
+    NSString *encodedString = (NSString *)CFURLCreateStringByAddingPercentEscapes(NULL,
+                                                                                  (CFStringRef)self,
+                                                                                  NULL,
+                                                                                  (CFStringRef)@"!*'();:@&=+$,/?%#[]",
+                                                                                  kCFStringEncodingUTF8);
+    return [encodedString autorelease];
+}
+
+@end

--- a/Forward-Geocoding.xcodeproj/project.pbxproj
+++ b/Forward-Geocoding.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0373787713A18ECC004A465E /* NSString+URLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = 0373787613A18ECC004A465E /* NSString+URLEncode.m */; };
 		1D3623260D0F684500981E51 /* Forward_GeocodingAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* Forward_GeocodingAppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -25,6 +26,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0373787513A18ECC004A465E /* NSString+URLEncode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+URLEncode.h"; sourceTree = "<group>"; };
+		0373787613A18ECC004A465E /* NSString+URLEncode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+URLEncode.m"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* Forward_GeocodingAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Forward_GeocodingAppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* Forward_GeocodingAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Forward_GeocodingAppDelegate.m; sourceTree = "<group>"; };
@@ -142,6 +145,8 @@
 				F4C7A375114CF462009DC9F7 /* BSKmlResult.m */,
 				F4C7A4BB114D5BD0009DC9F7 /* BSAddressComponent.h */,
 				F4C7A4BC114D5BD0009DC9F7 /* BSAddressComponent.m */,
+				0373787513A18ECC004A465E /* NSString+URLEncode.h */,
+				0373787613A18ECC004A465E /* NSString+URLEncode.m */,
 			);
 			name = "Forward Geocoding";
 			sourceTree = "<group>";
@@ -236,6 +241,7 @@
 				F4C7A41A114D02CB009DC9F7 /* CustomPlacemark.m in Sources */,
 				F4C7A4B0114D599D009DC9F7 /* BSGoogleV3KmlParser.m in Sources */,
 				F4C7A4BD114D5BD0009DC9F7 /* BSAddressComponent.m in Sources */,
+				0373787713A18ECC004A465E /* NSString+URLEncode.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This should fix issue #6. Created new method to URL encode completely (see references in method comment). Disclaimer: Untested and I'm relatively new to Objective-C.
