### PR TITLE
Remove NSLog call and add iVar

### DIFF
--- a/Classes/BSForwardGeocoder.h
+++ b/Classes/BSForwardGeocoder.h
@@ -40,6 +40,7 @@ enum {
 	NSString *googleAPiKey;
 	int status;
 	NSArray *results;
+	BOOL useHTTP;
 	id<BSForwardGeocoderDelegate> delegate;
 }
 - (id)initWithDelegate:(id<BSForwardGeocoderDelegate>)aDelegate;

--- a/Classes/BSForwardGeocoder.m
+++ b/Classes/BSForwardGeocoder.m
@@ -110,9 +110,6 @@
 	}
 	
 	[pool release];
-	
-	NSLog(@"Found placemarks: %d", [self.results count]);
-	
 }
 
 -(void)dealloc


### PR DESCRIPTION
Remove a debugging `NSLog` call (so it won't appear in production code), and explicitly declare the `useHTTP` instance variable (implicit declaration apparently isn't supported in versions before iOS 4).
