### PR TITLE
Fix wrong selector in delegate respondsToSelector check

### DIFF
--- a/Forward Geocoder/BSForwardGeocoder.m
+++ b/Forward Geocoder/BSForwardGeocoder.m
@@ -120,7 +120,7 @@
         if (!parseError && parser.statusCode == G_GEO_SUCCESS) {
             [self.delegate forwardGeocodingDidSucceed:self withResults:parser.results];
         }
-        else if ([self.delegate respondsToSelector:@selector(forwardGeocoderDidFail:withErrorMessage:)]) {
+        else if ([self.delegate respondsToSelector:@selector(forwardGeocodingDidFail:withErrorCode:andErrorMessage:)]) {
             [self.delegate forwardGeocodingDidFail:self withErrorCode:parser.statusCode andErrorMessage:[parseError localizedDescription]];
         }        
     }


### PR DESCRIPTION
The selector in `respondsToSelector` does not match the selector actually being called on the delegate, potentially leading to a crash.
